### PR TITLE
[hotfix] getAction add case Except Controller Name

### DIFF
--- a/src/RoutesCommand.php
+++ b/src/RoutesCommand.php
@@ -76,6 +76,8 @@ class RoutesCommand extends Command
             $data = $actionProp['uses'];
             if (($pos = strpos($data, "@")) !== false) {
                 return substr($data, $pos + 1);
+            } else {
+                return "Not Controller";
             }
         } else {
             return 'Closure func';


### PR DESCRIPTION
- getActionメソッド
  @付きではないコントローラーの場合の挙動を追加
